### PR TITLE
[feat] - 型の互換性(48.type-compatibility.ts)

### DIFF
--- a/src/46.abstract-class.ts
+++ b/src/46.abstract-class.ts
@@ -28,7 +28,7 @@ class Lion extends Animal {
 
 // 抽象メソッドで定義されているcry()が実装されていないとエラーになり、実装忘れなどを防ぐ事ができる。
 class Tiger extends Animal {
-    cry() {
-        return 'grrr';
-    }
+    // cry() {
+    //     return 'grrr';
+    // }
 }

--- a/src/47.return-of-interfaces.ts
+++ b/src/47.return-of-interfaces.ts
@@ -1,0 +1,46 @@
+export {};
+
+/** 
+ * インターフェース（interface）とは、TypeScriptにおいてクラスが実装すべきメソッドやプロパティのシグネチャーを定義するための構造です。
+ * インターフェース自体は実装を持たず、クラスがそのインターフェースを実装することで、特定のメソッドやプロパティを持つことを保証します。
+ *  1. 複数のインターフェースの実装: TypeScriptでは、クラスは複数のインターフェースを実装することができます。
+ *     これにより、異なる機能を持つクラスを作成することが可能です。
+ *  2. シグネチャーの定義: インターフェースは、メソッドの名前、引数、戻り値の型を定義しますが、実際の処理内容は持ちません。
+ *  3. クラスとの関係: クラスはimplementsキーワードを使用してインターフェースを実装します。
+ *     インターフェースで定義されたメソッドをすべて実装しないと、コンパイルエラーが発生します。
+*/
+class Mahoutsukai {}
+class Souryo {}
+
+//TypeScriptは、単一のClassしか継承ができない仕様になっている。
+//以下のように記載するとコンパイルエラーになる。
+class Taro extends Mahoutsukai, Souryo{}
+
+
+//interfaceであれば、複数継承する事が可能
+//ただし本来interfaceは継承ではなく実装になるので、
+//正しくは複数のinterfaceをベースにclassを実装(implement)することが可能
+
+//interfaceを定義して、処理の実態のないSignatureを定義する
+interface Kenja {
+    ionazun(): void;    //Signatureの定義
+}
+interface Senshi {
+    kougeki(): void;    //Signatureの定義
+}
+
+// interfaceからclassを実装する場合は'implements'を利用する
+class Jiro implements Kenja, Senshi{
+    // ただし、interfaceで定義している｢イオナズン｣と｢攻撃｣が実装されていないとコンパイルエラーになる
+}
+
+// interfaceのシグネチャー通りに、classが実装されるとコンパイルエラーは解消される
+class Hanako implements Kenja, Senshi{
+    ionazun(): void {
+        console.log('イオナズンを唱えた');
+    }
+    kougeki(): void {
+        console.log('攻撃をした');
+    }
+}
+

--- a/src/48.type-compatibility.ts
+++ b/src/48.type-compatibility.ts
@@ -1,0 +1,74 @@
+export {};
+
+/** 型の互換性とは
+ *  型の互換性あり → ある型に対して、別の形を代入できる
+ *  型の互換性なし → ある型に対して、別の形を代入できない
+ */
+
+let hogeCompatible: any;
+let mogeCompatible: string = 'TypeScript';
+
+console.log('🚀🚀🚀🚀🚀 ~ hogeCompatible:', typeof hogeCompatible);
+
+// string は any に互換性がある
+hogeCompatible = mogeCompatible;
+
+console.log('🚀🚀🚀🚀🚀 ~ hogeCompatible:', typeof hogeCompatible);
+
+let hogeInCompatible: string;
+let mogeInCompatible: number = 1;
+
+// number は string に互換性がない
+hogeInCompatible = mogeInCompatible;
+
+let hogeString: string;
+let mogeString: string = 'string';
+
+// string は string に互換性あり
+hogeString = mogeString;
+
+let hogeStringLiteral: 'hogeStringLiteral' = 'hogeStringLiteral';
+let mogeStringLiteral: 'mogeStringLiteral' = 'mogeStringLiteral';
+// stringLiteral型は、string型と互換性がある
+hogeString = hogeStringLiteral;
+// string Literal型は、Literal型と互換性がない
+hogeStringLiteral = mogeStringLiteral;
+
+let hogeNumber: number;
+let hogeNumberLiteral: 1976 = 1976;
+// numberLiteral型は、number型と互換性がある
+hogeNumber = hogeNumberLiteral;
+
+/**構造的部分型
+ * オブジェクトの構造（プロパティやメソッドの形）に基づいて型の互換性を判断します。
+ * 代入元の型が持つプロパティやメソッドが、
+ * 代入先の型に必要なプロパティやメソッドをすべて持っているかどうかによって決まります。
+ *
+ * ※同じプロパティを持つ限り、異なる型のオブジェクト同士でも互換性があると見なされます。
+ */
+
+// 代入元の型: Person
+class Person {
+    constructor(public age: number) {}
+}
+
+// 1. 互換性のある型: 同一の構造(メンバー変数)
+// 代入元: classのPerson(メンバー変数がageのみ)
+// 代入先: interfaceのAnimal_1を実装した、me_1 (メンバー変数がageのみ)
+interface Animal_1 {
+    age: number;
+}
+
+let me_1: Animal_1;
+me_1 = new Person(39); // 互換性あり
+
+// 1. 互換性のない型: 非同一の構造(メンバー変数)
+// 代入元: classのPerson(メンバー変数がageとname)
+// 代入先: interfaceのAnimal_1を実装した、me_1 (メンバー変数がageのみ)
+interface Animal_2 {
+    age: number;
+    name: string;
+}
+
+let me_2: Animal_2;
+me_2 = new Person(30, 'Taro'); // 互換性なし


### PR DESCRIPTION
## 目的
- 48.type-compatibility.ts で学んだ型の互換性についてのまとめ

## 関連リンク
- https://ibmcsr.udemy.com/course/ts-for-js-developers/learn/lecture/17896952#overview

## 実装内容
- Primitive型の互換性の説明とサンプル
- 構造的部分型の互換性の説明とサンプル

## 動作確認項目
- なし

## 特にレビューしてほしい点
- [ ] 説明文とサンプルコードに誤りが無いか
- [ ] 内容が第三者が読んでわかりやすいか

## 対象外の範囲
- なし